### PR TITLE
fix typo in section error msg

### DIFF
--- a/fuzzers/generic_fuzzer.py
+++ b/fuzzers/generic_fuzzer.py
@@ -47,7 +47,7 @@ class CGenericFuzzer:
     parser.read(self.cfg)
 
     if self.section not in parser.sections():
-      raise Exception("Section %s does not exists in the given configuration file" % self.section)
+      raise Exception("Section %s does not exist in the given configuration file" % self.section)
     
     try:
       self.pre_command = parser.get(self.section, 'pre-command')


### PR DESCRIPTION
this PR isn't remotely important, but it fixes a typo in the error message raised when a config file section cannot be found.  Changes "Section %s does not exists ..." to "Section %s does not exist ..."