### PR TITLE
Minor bug introduced in cpu autokill

### DIFF
--- a/lib/interfaces/pykd_iface.py
+++ b/lib/interfaces/pykd_iface.py
@@ -251,7 +251,7 @@ class CWinDbgInterface(object):
       self.handler = ExceptionHandler()
 
     if self.timeout is not None:
-      if self.timeout.lower() == "auto":
+      if type(self.timeout) is str and self.timeout.lower() == "auto":
         self.thread = Thread(target=self.check_cpu)
         self.thread.start()
       else:


### PR DESCRIPTION
Checked if timeout was .lower == "auto" before determining if it was a string.